### PR TITLE
Bump ANTLR Version

### DIFF
--- a/ottercraft-fabric-1.18.2/build.gradle
+++ b/ottercraft-fabric-1.18.2/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     implementation(include('org.tomlj:tomlj:1.0.0'))
-	implementation(include('org.antlr:antlr4-runtime:4.7.2'))
+	implementation(include('org.antlr:antlr4-runtime:4.11.1'))
 }
 
 processResources {


### PR DESCRIPTION
Fixes issue caused with Iris 1.4.x replacing ANTLR runtime with newer version.